### PR TITLE
Add default bindings

### DIFF
--- a/osu.Game.Rulesets.Theater/TheaterInputManager.cs
+++ b/osu.Game.Rulesets.Theater/TheaterInputManager.cs
@@ -23,10 +23,28 @@ namespace osu.Game.Rulesets.Theater
         [Description("Right Tap Button")]
         RightTapButton,
 
-        [Description("Left Direction Stick")]
-        LeftStick,
+        [Description("Left Analog Stick: Left")]
+        LeftAnalogLeftDirection,
 
-        [Description("Right Direction Stick")]
-        RightStick,
+        [Description("Left Analog Stick: Right")]
+        LeftAnalogRightDirection,
+
+        [Description("Left Analog Stick: Up")]
+        LeftAnalogUpDirection,
+
+        [Description("Left Analog Stick: Down")]
+        LeftAnalogDownDirection,
+
+        [Description("Right Analog Stick: Left")]
+        RightAnalogLeftDirection,
+
+        [Description("Right Analog Stick: Right")]
+        RightAnalogRightDirection,
+
+        [Description("Right Analog Stick: Up")]
+        RightAnalogUpDirection,
+
+        [Description("Right Analog Stick: Down")]
+        RightAnalogDownDirection,
     }
 }

--- a/osu.Game.Rulesets.Theater/TheaterRuleset.cs
+++ b/osu.Game.Rulesets.Theater/TheaterRuleset.cs
@@ -45,8 +45,16 @@ namespace osu.Game.Rulesets.Theater
 
         public override IEnumerable<KeyBinding> GetDefaultKeyBindings(int variant = 0) => new[]
         {
-            new KeyBinding(InputKey.Z, TheaterAction.LeftTapButton),
-            new KeyBinding(InputKey.M, TheaterAction.RightTapButton),
+            new KeyBinding(InputKey.Joystick5, TheaterAction.LeftTapButton),
+            new KeyBinding(InputKey.Joystick6, TheaterAction.RightTapButton),
+            new KeyBinding(InputKey.JoystickAxis1Negative, TheaterAction.LeftAnalogLeftDirection),
+            new KeyBinding(InputKey.JoystickAxis1Positive, TheaterAction.LeftAnalogRightDirection),
+            new KeyBinding(InputKey.JoystickAxis2Negative, TheaterAction.LeftAnalogUpDirection),
+            new KeyBinding(InputKey.JoystickAxis2Positive, TheaterAction.LeftAnalogDownDirection),
+            new KeyBinding(InputKey.JoystickAxis4Negative, TheaterAction.RightAnalogLeftDirection),
+            new KeyBinding(InputKey.JoystickAxis4Positive, TheaterAction.RightAnalogRightDirection),
+            new KeyBinding(InputKey.JoystickAxis5Negative, TheaterAction.RightAnalogUpDirection),
+            new KeyBinding(InputKey.JoystickAxis5Positive, TheaterAction.RightAnalogDownDirection),
         };
 
         public override Drawable CreateIcon() => new SpriteText


### PR DESCRIPTION
Add default key bindings that use dual analog joystick controls.
The idea is that we will support the arcade style for Theatrhythm by default so that each stick can be used to input directional swipes and each trigger can hit the beats. In the arcade, sometimes two simultaneous inputs are required, hence the need for two sticks and both triggers.
The goal will be to have beatmaps that support both single input (a la 3DS/iOS version) and dual input (arcade version) for all difficulties. Dual input beatmaps could be possible with dual analog controllers or multi-input touchscreens, but not with keyboard and/or mouse. Single input beatmaps could be possible with mouse and keyboard as well, probably in combination with each other.